### PR TITLE
Adjusted the parameters used for sleep between retries

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -203,9 +203,9 @@ type decorrelatedJitter struct {
 func newJitter() decorrelatedJitter {
 	rand.Seed(time.Now().UnixNano())
 	return decorrelatedJitter{
-		duration: 5e9,
-		min:      5e9, //5s
-		cap:      10e9,
+		duration: 15e9,
+		min:      15e9, //15s
+		cap:      30e9,
 	}
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -203,9 +203,9 @@ type decorrelatedJitter struct {
 func newJitter() decorrelatedJitter {
 	rand.Seed(time.Now().UnixNano())
 	return decorrelatedJitter{
-		duration: 1,
-		min:      1,
-		cap:      10,
+		duration: 5e9,
+		min:      5e9, //5s
+		cap:      10e9,
 	}
 }
 
@@ -214,6 +214,7 @@ func (d *decorrelatedJitter) calc() {
 }
 
 func (d *decorrelatedJitter) sleep() {
+	d.calc()
 	time.Sleep(time.Duration(d.duration))
 }
 


### PR DESCRIPTION
In case of errors, there already existed sleep() before retry. But the sleep was being configured for 1ns duration. Fixed it.